### PR TITLE
Y-tunnus ei voi olla primary key.

### DIFF
--- a/src/main/resources/db/migration/V20191023050756__ytunnus_rajoitteen_poisto.sql
+++ b/src/main/resources/db/migration/V20191023050756__ytunnus_rajoitteen_poisto.sql
@@ -1,0 +1,2 @@
+ALTER TABLE organisaatio DROP CONSTRAINT organisaatio_pkey;
+ALTER TABLE organisaatio ADD PRIMARY KEY (rekisterointi_id);


### PR DESCRIPTION
Hylätyn hakemuksen tilalle pitää olla mahdollista
luoda uusi. Poistetaan primary key constraint, ja luodaan
uusi rekisterointi_id:lle.