### PR TITLE
Korjaus puuttuvaan ytj-kieliseen nimeen.

### DIFF
--- a/src/main/java/fi/vm/sade/varda/rekisterointi/service/OrganisaatioService.java
+++ b/src/main/java/fi/vm/sade/varda/rekisterointi/service/OrganisaatioService.java
@@ -1,6 +1,8 @@
 package fi.vm.sade.varda.rekisterointi.service;
 
 import fi.vm.sade.varda.rekisterointi.model.*;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
 
 import java.time.LocalDate;
@@ -12,6 +14,8 @@ import static java.time.temporal.ChronoUnit.DAYS;
 
 @Service
 public class OrganisaatioService {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(OrganisaatioService.class);
 
     private static final String DEFAULT_KIELI_KOODI_URI_VERSION = "kieli_fi#1";
     private static final String DEFAULT_KIELI_KOODI_ARVO = "fi";
@@ -69,7 +73,8 @@ public class OrganisaatioService {
         String kieli = kieliKoodiUriVersionToKoodiArvo(ytjKieli);
         String ytjKielinen = kurantti.nimi.getOrDefault(kieli, kurantti.nimi.get(DEFAULT_KIELI_KOODI_ARVO));
         if (ytjKielinen == null) {
-            throw new IllegalStateException("Ei YTJ-kielen tai oletuskielen mukaista nimeä organisaatiolle: " + dto.ytunnus);
+            LOGGER.warn("Ei YTJ-kielen tai oletuskielen mukaista nimeä organisaatiolle: {}", dto.ytunnus);
+            ytjKielinen = "";
         }
         return KielistettyNimi.of(ytjKielinen, kieli, kurantti.alkuPvm);
     }

--- a/src/test/java/fi/vm/sade/varda/rekisterointi/service/OrganisaatioServiceTest.java
+++ b/src/test/java/fi/vm/sade/varda/rekisterointi/service/OrganisaatioServiceTest.java
@@ -16,18 +16,19 @@ public class OrganisaatioServiceTest {
     private final OrganisaatioService service = new OrganisaatioService();
 
     @Test(expected = IllegalStateException.class)
-    public void kuranttiNimiThrowsWhenNoCurrentName() {
+    public void kuranttiNimiThrowsWhenNoName() {
         OrganisaatioV4Dto dto = new OrganisaatioV4Dto();
-        dto.nimet = Collections.singletonList(organisaatioNimi(LocalDate.MAX, null, null));
+        dto.nimet = Collections.emptyList();
         service.kuranttiNimi(dto);
     }
 
-    @Test(expected = IllegalStateException.class)
-    public void kuranttiNimiThrowsWhenNoNameMatchingLanguage() {
+    @Test
+    public void kuranttiNimiReturnsBlankWhenNoNameMatchingLanguage() {
         OrganisaatioV4Dto dto = new OrganisaatioV4Dto();
-        dto.nimet = Collections.singletonList(organisaatioNimi(LocalDate.MIN, "en", null));
-        dto.ytjkieli = "sv";
-        service.kuranttiNimi(dto);
+        dto.nimet = Collections.singletonList(organisaatioNimi(LocalDate.MIN, "en", "Finnish name missing!"));
+        dto.ytjkieli = "fi";
+        KielistettyNimi kuranttiNimi = service.kuranttiNimi(dto);
+        assertEquals("", kuranttiNimi.nimi);
     }
 
     @Test


### PR DESCRIPTION
Ei heitetä poikkeusta, vaan palautetaan tyhjä.