### PR TITLE
Muutettu yrityksen nimen tarkastusta siten, että jos ytj-kielistä nim…

### DIFF
--- a/src/main/java/fi/vm/sade/varda/rekisterointi/service/OrganisaatioService.java
+++ b/src/main/java/fi/vm/sade/varda/rekisterointi/service/OrganisaatioService.java
@@ -71,7 +71,7 @@ public class OrganisaatioService {
                 .orElseThrow(() -> new IllegalStateException("Ei voimassa olevaa nimeä organisaatiolle: " + dto.ytunnus));
         String ytjKieli = ytjKieliTaiOletusKieli(dto);
         String kieli = kieliKoodiUriVersionToKoodiArvo(ytjKieli);
-        String ytjKielinen = kurantti.nimi.getOrDefault(kieli, kurantti.nimi.get(DEFAULT_KIELI_KOODI_ARVO));
+        String ytjKielinen = kurantti.nimi.getOrDefault(kieli, kurantti.nimi.getOrDefault("sv", kurantti.nimi.get(DEFAULT_KIELI_KOODI_ARVO)));
         if (ytjKielinen == null) {
             LOGGER.warn("Ei YTJ-kielen tai oletuskielen mukaista nimeä organisaatiolle: {}", dto.ytunnus);
             ytjKielinen = "";

--- a/src/test/java/fi/vm/sade/varda/rekisterointi/service/OrganisaatioServiceTest.java
+++ b/src/test/java/fi/vm/sade/varda/rekisterointi/service/OrganisaatioServiceTest.java
@@ -25,7 +25,7 @@ public class OrganisaatioServiceTest {
     @Test
     public void kuranttiNimiReturnsBlankWhenNoNameMatchingLanguage() {
         OrganisaatioV4Dto dto = new OrganisaatioV4Dto();
-        dto.nimet = Collections.singletonList(organisaatioNimi(LocalDate.MIN, "en", "Finnish name missing!"));
+        dto.nimet = Collections.singletonList(organisaatioNimi(LocalDate.MIN, "en", "Finnish and Swedish names missing!"));
         dto.ytjkieli = "fi";
         KielistettyNimi kuranttiNimi = service.kuranttiNimi(dto);
         assertEquals("", kuranttiNimi.nimi);


### PR DESCRIPTION
…eä ei löydy, niin yritetään etsiä myös ruotsinkielistä, ja sen jälkeen vielä järjestelmän default kieltä(Joka on Suomi). Jos mitään näistä ei löydy, palautetaan nimeksi tyhjä.