### PR TITLE
Yritysmuotovalidoinnin ja listauksen korjaus.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -139,6 +139,11 @@
                         </goals>
                     </execution>
                 </executions>
+                <configuration>
+                    <systemPropertyVariables>
+                        <db.port>${database.port}</db.port>
+                    </systemPropertyVariables>
+                </configuration>
             </plugin>
             <plugin>
                 <groupId>org.springframework.boot</groupId>
@@ -196,6 +201,24 @@
                 </executions>
             </plugin>
             <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>build-helper-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>reserve-db-port</id>
+                        <goals>
+                            <goal>reserve-network-port</goal>
+                        </goals>
+                        <phase>pre-integration-test</phase>
+                        <configuration>
+                            <portNames>
+                                <portName>database.port</portName>
+                            </portNames>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
                 <groupId>io.fabric8</groupId>
                 <artifactId>docker-maven-plugin</artifactId>
                 <version>0.31.0</version>
@@ -211,7 +234,7 @@
                                     <POSTGRES_DB>varda-rekisterointi</POSTGRES_DB>
                                 </env>
                                 <ports>
-                                    <port>5432:5432</port>
+                                    <port>${database.port}:5432</port>
                                 </ports>
                                 <wait>
                                     <tcp>

--- a/src/frontend/hakija/YritysmuotoUtils.ts
+++ b/src/frontend/hakija/YritysmuotoUtils.ts
@@ -1,33 +1,33 @@
 import { Koodi, Language } from "../types";
 
 export const kielletytYritysmuodot = [
-    'Kunta',
-    'Kuntayhtymä',
+    'yritysmuoto_41', //'Kunta',
+    'yritysmuoto_42' //'Kuntayhtymä',
 ];
 
 const yritysmuotoPriorityList = [
-    'Aatteellinen yhdistys',
-    'Avoin yhtiö',
-    'Ei yritysmuotoa',
-    'Ev.lut.kirkko',
-    'Julkinen osakeyhtiö',
-    'Kommandiittiyhtiö',
-    'Muu julkisoikeudellinen oikeushenkilö',
-    'Muu säätiö',
-    'Muu taloudellinen yhdistys',
-    'Muu verotuksen yksikkö',
-    'Muu yhdistys',
-    'Muu yhteisvast.pidätysvelvollinen',
-    'Muu yhtiö',
-    'Muut oikeushenkilöt',
-    'Ortodoksinen kirkko',
-    'Osakeyhtiö',
-    'Osuuskunta',
-    'Rekisteröity uskonnollinen yhdyskunta',
-    'Sivuliike',
-    'Säätiö',
-    'Taloudellinen yhdistys',
-    'Yksityinen elinkeinonharjoittaja'
+    'yritysmuoto_6', //'Aatteellinen yhdistys',
+    'yritysmuoto_5', //'Avoin yhtiö',
+    'yritysmuoto_0', //'Ei yritysmuotoa',
+    'yritysmuoto_44', //'Ev.lut.kirkko',
+    'yritysmuoto_17', //'Julkinen osakeyhtiö',
+    'yritysmuoto_13', //'Kommandiittiyhtiö',
+    'yritysmuoto_49', //'Muu julkisoikeudellinen oikeushenkilö',
+    'yritysmuoto_39', //'Muu säätiö',
+    'yritysmuoto_38', //'Muu taloudellinen yhdistys',
+    'yritysmuoto_59', //'Muu verotuksen yksikkö',
+    'yritysmuoto_29', //'Muu yhdistys',
+    'yritysmuoto_52', //'Muu yhteisvast.pidätysvelvollinen',
+    'yritysmuoto_30', //'Muu yhtiö',
+    'yritysmuoto_63', //'Muut oikeushenkilöt',
+    'yritysmuoto_45', //'Ortodoksinen kirkko',
+    'yritysmuoto_16', //'Osakeyhtiö',
+    'yritysmuoto_14', //'Osuuskunta',
+    'yritysmuoto_46', //'Rekisteröity uskonnollinen yhdyskunta',
+    'yritysmuoto_19', //'Sivuliike',
+    'yritysmuoto_18', //'Säätiö',
+    'yritysmuoto_21', //'Taloudellinen yhdistys',
+    'yritysmuoto_26', //'Yksityinen elinkeinonharjoittaja'
 ];
 
 export function yritysmuotoSortFnByLanguage(language: Language) {

--- a/src/test/resources/application-integration-test.yml
+++ b/src/test/resources/application-integration-test.yml
@@ -1,4 +1,6 @@
 spring:
+  datasource:
+    url: jdbc:postgresql://localhost:${db.port}/varda-rekisterointi
   session:
     store-type: none
 db-scheduler:


### PR DESCRIPTION
Siirtyminen kovakoodatuista yritysmuodoista koodiston
käyttämiseen rikkoi validoinnin ja listauksen priorisoinnin,
korjattu muuttamalla validointi- ja listauskoodi käyttämään
koodiston koodeja.

Drive by -hengessä muutettu integrointitestit polkaisemaan
tietokanta satunnaisesti valittuun vapaaseen porttiin, jotta
ajossa oleva kanta ei aiheuta porttikonfliktia.